### PR TITLE
remove IncreaseAllowance & add shared nonce

### DIFF
--- a/channel/conclude.go
+++ b/channel/conclude.go
@@ -42,6 +42,7 @@ const (
 // - it searches for a past concluded event by calling `isConcluded`
 //   - if found, channel is already concluded and success is returned
 //   - if none found, conclude/concludeFinal is called on the adjudicator
+//
 // - it waits for a Concluded event from the blockchain.
 func (a *Adjudicator) ensureConcluded(ctx context.Context, req channel.AdjudicatorReq, subStates channel.StateMap) error {
 	// Check whether it is already concluded.

--- a/channel/contractbackend.go
+++ b/channel/contractbackend.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"math/big"
 	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
@@ -241,13 +240,11 @@ func (c *ContractBackend) confirmNTimes(ctx context.Context, tx *types.Transacti
 	if finalityDepth < 1 {
 		return nil, errors.New("finalityDepth was less than 1")
 	}
-	startWaitMined := time.Now()
 	// Wait to be included at least once.
 	head, err := c.waitMined(ctx, tx)
 	if err != nil {
 		return nil, errors.WithMessage(err, "waiting for TX to be mined")
 	}
-	log.Printf("WaitMined of tx %s in %s; Start: %s ; End: %s", tx.Hash().Hex(), time.Since(startWaitMined), startWaitMined, time.Now())
 
 	// Set up header sub for future blocks.
 	heads := make(chan *types.Header, contractBackendHeadBuffSize)
@@ -259,7 +256,6 @@ func (c *ContractBackend) confirmNTimes(ctx context.Context, tx *types.Transacti
 	}
 	defer hsub.Unsubscribe()
 
-	startPollReceipt := time.Now()
 	for {
 		select {
 		case head := <-heads:
@@ -271,17 +267,14 @@ func (c *ContractBackend) confirmNTimes(ctx context.Context, tx *types.Transacti
 				break
 			}
 			if receipt != nil && isFinal(receipt, head, finalityDepth) {
-				log.Printf("PollReceipt for Tx %s in %s", tx.Hash().Hex(), time.Since(startPollReceipt))
 				return receipt, nil
 			}
 			// TX is either not included in the canonical chain anymore
 			// or not yet final; wait for next head.
 		case err := <-hsub.Err():
 			err = cherrors.CheckIsChainNotReachableError(err)
-			log.Printf("PollReceipt for Tx %s in %s", tx.Hash().Hex(), time.Since(startPollReceipt))
 			return nil, errors.WithMessage(err, "header subscription")
 		case <-ctx.Done():
-			log.Printf("PollReceipt for Tx %s in %s", tx.Hash().Hex(), time.Since(startPollReceipt))
 			return nil, ctx.Err()
 		}
 	}

--- a/channel/contractbackend.go
+++ b/channel/contractbackend.go
@@ -46,10 +46,14 @@ const (
 // create a TxTimedoutError with additional context.
 var errTxTimedOut = errors.New("")
 
+// SharedExpected Nonce is a map of each expected next nonce of all clients.
 var (
-	GlobalExpectedNonces map[ChainID]map[common.Address]uint64
-	GlobalNonceMtx       map[ChainID]map[common.Address]*sync.Mutex
+	SharedExpectedNonces map[ChainID]map[common.Address]uint64
+	SharedNonceMtx       map[ChainID]map[common.Address]*sync.Mutex
 )
+
+// SharedMutex controls the reads and writes on the nonceMtx and ecpectedNextNonce of the ContractBackend.
+var SharedMutex = &sync.Mutex{}
 
 // ContractInterface provides all functions needed by an ethereum backend.
 // Both test.SimulatedBackend and ethclient.Client implement this interface.
@@ -79,24 +83,24 @@ type ContractBackend struct {
 // txFinalityDepth defines in how many consecutive blocks a TX has to be
 // included to be considered final. Must be at least 1.
 func NewContractBackend(cf ContractInterface, chainID ChainID, tr Transactor, txFinalityDepth uint64) ContractBackend {
-	// Check if the global maps are initialized, if not, initialize them.
-	if GlobalExpectedNonces == nil {
-		GlobalExpectedNonces = make(map[ChainID]map[common.Address]uint64)
+	// Check if the shared maps are initialized, if not, initialize them.
+	if SharedExpectedNonces == nil {
+		SharedExpectedNonces = make(map[ChainID]map[common.Address]uint64)
 	}
-	if GlobalNonceMtx == nil {
-		GlobalNonceMtx = make(map[ChainID]map[common.Address]*sync.Mutex)
+	if SharedNonceMtx == nil {
+		SharedNonceMtx = make(map[ChainID]map[common.Address]*sync.Mutex)
 	}
 
-	// Check if the specific chainID entry exists in the global maps, if not, create it.
-	if _, exists := GlobalExpectedNonces[chainID]; !exists {
-		GlobalExpectedNonces[chainID] = make(map[common.Address]uint64)
-		GlobalNonceMtx[chainID] = make(map[common.Address]*sync.Mutex)
+	// Check if the specific chainID entry exists in the shared maps, if not, create it.
+	if _, exists := SharedExpectedNonces[chainID]; !exists {
+		SharedExpectedNonces[chainID] = make(map[common.Address]uint64)
+		SharedNonceMtx[chainID] = make(map[common.Address]*sync.Mutex)
 	}
 	return ContractBackend{
 		ContractInterface: cf,
 		tr:                tr,
-		expectedNextNonce: GlobalExpectedNonces[chainID],
-		nonceMtx:          GlobalNonceMtx[chainID],
+		expectedNextNonce: SharedExpectedNonces[chainID],
+		nonceMtx:          SharedNonceMtx[chainID],
 		txFinalityDepth:   txFinalityDepth,
 		chainID:           chainID,
 	}
@@ -184,12 +188,7 @@ func (c *ContractBackend) nonce(ctx context.Context, sender common.Address) (uin
 		err = cherrors.CheckIsChainNotReachableError(err)
 		return 0, errors.WithMessage(err, "fetching nonce")
 	}
-	// Look up expected next nonce locally.
-	if c.nonceMtx[sender] == nil {
-		c.nonceMtx[sender] = &sync.Mutex{}
-	}
-	c.nonceMtx[sender].Lock()
-	defer c.nonceMtx[sender].Unlock()
+	SharedMutex.Lock()
 	expectedNextNonce, found := c.expectedNextNonce[sender]
 	if !found {
 		c.expectedNextNonce[sender] = 0
@@ -202,6 +201,7 @@ func (c *ContractBackend) nonce(ctx context.Context, sender common.Address) (uin
 
 	// Update local expectation.
 	c.expectedNextNonce[sender] = nonce + 1
+	SharedMutex.Unlock()
 	return nonce, nil
 }
 
@@ -285,7 +285,6 @@ func (c *ContractBackend) confirmNTimes(ctx context.Context, tx *types.Transacti
 			return nil, ctx.Err()
 		}
 	}
-
 }
 
 // waitMined waits for a TX to be mined and returns the latest head.

--- a/channel/erc20_depositor.go
+++ b/channel/erc20_depositor.go
@@ -16,10 +16,15 @@ package channel
 
 import (
 	"context"
+	"fmt"
+	"math/big"
+	"sync"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
+	"perun.network/go-perun/log"
 
 	"github.com/perun-network/perun-eth-backend/bindings/assetholdererc20"
 	"github.com/perun-network/perun-eth-backend/bindings/peruntoken"
@@ -40,44 +45,137 @@ const ERC20DepositorTXGasLimit = 100000
 // Return value of ERC20Depositor.NumTx.
 const erc20DepositorNumTx = 2
 
+// Keep track of the increase allowance and deposit processes.
+var mu sync.Mutex
+var locks = make(map[string]*sync.Mutex)
+
+// DepositResult is created to keep track of the returned values.
+type DepositResult struct {
+	Transactions types.Transactions
+	Error        error
+}
+
+// Create key from account address and asset to only lock the process when hub deposits the same asset at the same time.
+func lockKey(account common.Address, asset common.Address) string {
+	return fmt.Sprintf("%s-%s", account.Hex(), asset.Hex())
+}
+
+// Retrieves Lock for specific key.
+func handleLock(lockKey string) *sync.Mutex {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if lock, exists := locks[lockKey]; exists {
+		return lock
+	}
+
+	lock := &sync.Mutex{}
+	locks[lockKey] = lock
+	return lock
+}
+
+// Locks the lock argument, runs the given function and then unlocks the lock argument.
+func lockAndUnlock(lock *sync.Mutex, fn func()) {
+	mu.Lock()
+	defer mu.Unlock()
+	lock.Lock()
+	defer lock.Unlock()
+	fn()
+}
+
 // NewERC20Depositor creates a new ERC20Depositor.
 func NewERC20Depositor(token common.Address) *ERC20Depositor {
 	return &ERC20Depositor{Token: token}
 }
 
-// Deposit deposits ERC20 tokens into the ERC20 AssetHolder specified at the
-// request's asset address.
+// Deposit approves the value to be swapped and calls DepositOnly.
+// nolint:funlen
 func (d *ERC20Depositor) Deposit(ctx context.Context, req DepositReq) (types.Transactions, error) {
-	// Bind a `AssetHolderERC20` instance.
-	assetholder, err := assetholdererc20.NewAssetholdererc20(req.Asset.EthAddress(), req.CB)
-	if err != nil {
-		return nil, errors.Wrapf(err, "binding AssetHolderERC20 contract at: %x", req.Asset)
-	}
+	lockKey := lockKey(req.Account.Address, req.Asset.EthAddress())
+	lock := handleLock(lockKey)
+
 	// Bind an `ERC20` instance.
 	token, err := peruntoken.NewPeruntoken(d.Token, req.CB)
 	if err != nil {
 		return nil, errors.Wrapf(err, "binding ERC20 contract at: %x", d.Token)
 	}
-	// Increase the allowance.
+	callOpts := bind.CallOpts{
+		Pending: false,
+		Context: ctx,
+	}
+	// variables for the return value.
+	var depResult DepositResult
+	var approvalReceived bool
+	var tx1 *types.Transaction
+	var err1 error
+	lockAndUnlock(lock, func() {
+		allowance, err := token.Allowance(&callOpts, req.Account.Address, req.Asset.EthAddress())
+		if err != nil {
+			depResult.Transactions = nil
+			depResult.Error = errors.WithMessagef(err, "could not get Allowance for asset: %x", req.Asset)
+		}
+		result := new(big.Int).Add(req.Balance, allowance)
+
+		// Increase the allowance.
+		opts, err := req.CB.NewTransactor(ctx, ERC20DepositorTXGasLimit, req.Account)
+		if err != nil {
+			depResult.Transactions = nil
+			depResult.Error = errors.WithMessagef(err, "creating transactor for asset: %x", req.Asset)
+		}
+		// Create a channel for receiving PeruntokenApproval events
+		eventSink := make(chan *peruntoken.PeruntokenApproval)
+
+		// Create a channel for receiving the Approval event
+		eventReceived := make(chan bool)
+
+		// Watch for Approval events and send them to the eventSink
+		subscription, err := token.WatchApproval(&bind.WatchOpts{Start: nil, Context: ctx}, eventSink, []common.Address{req.Account.Address}, []common.Address{req.Asset.EthAddress()})
+		if err != nil {
+			depResult.Transactions = nil
+			depResult.Error = errors.WithMessagef(err, "Cannot listen for event")
+		}
+		tx1, err1 = token.Approve(opts, req.Asset.EthAddress(), result)
+		if err1 != nil {
+			err = cherrors.CheckIsChainNotReachableError(err)
+			depResult.Transactions = nil
+			depResult.Error = errors.WithMessagef(err, "increasing allowance for asset: %x", req.Asset)
+		}
+
+		go func() {
+			select {
+			case event := <-eventSink:
+				log.Printf("Received Approval event: Owner: %s, Spender: %s, Value: %s\n", event.Owner.Hex(), event.Spender.Hex(), event.Value.String())
+				eventReceived <- true
+			case err := <-subscription.Err():
+				log.Println("Subscription error:", err)
+			}
+		}()
+		approvalReceived = <-eventReceived
+	})
+	if approvalReceived {
+		tx2, err := d.DepositOnly(ctx, req)
+		depResult.Transactions = []*types.Transaction{tx1, tx2}
+		depResult.Error = errors.WithMessage(err, "AssetHolderERC20 depositing")
+	}
+	return depResult.Transactions, depResult.Error
+}
+
+// DepositOnly deposits ERC20 tokens into the ERC20 AssetHolder specified at the
+// requests asset address.
+func (d *ERC20Depositor) DepositOnly(ctx context.Context, req DepositReq) (*types.Transaction, error) {
+	// Bind a `AssetHolderERC20` instance.
+	assetholder, err := assetholdererc20.NewAssetholdererc20(req.Asset.EthAddress(), req.CB)
+	if err != nil {
+		return nil, errors.Wrapf(err, "binding AssetHolderERC20 contract at: %x", req.Asset)
+	}
+	// Deposit.
 	opts, err := req.CB.NewTransactor(ctx, ERC20DepositorTXGasLimit, req.Account)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "creating transactor for asset: %x", req.Asset)
 	}
-	// tx0, err := token.IncreaseAllowance(opts, req.Asset.EthAddress(), req.Balance)
-	tx1, err := token.Approve(opts, req.Asset.EthAddress(), req.Balance)
 
-	if err != nil {
-		err = cherrors.CheckIsChainNotReachableError(err)
-		return nil, errors.WithMessagef(err, "increasing allowance for asset: %x", req.Asset)
-	}
-	// Deposit.
-	opts, err = req.CB.NewTransactor(ctx, ERC20DepositorTXGasLimit, req.Account)
-	if err != nil {
-		return nil, errors.WithMessagef(err, "creating transactor for asset: %x", req.Asset)
-	}
 	tx2, err := assetholder.Deposit(opts, req.FundingID, req.Balance)
-	err = cherrors.CheckIsChainNotReachableError(err)
-	return []*types.Transaction{tx1, tx2}, errors.WithMessage(err, "AssetHolderERC20 depositing")
+	return tx2, err
 }
 
 // NumTX returns 2 since it does IncreaseAllowance and Deposit.

--- a/channel/erc20_depositor.go
+++ b/channel/erc20_depositor.go
@@ -89,7 +89,8 @@ func NewERC20Depositor(token common.Address) *ERC20Depositor {
 }
 
 // Deposit approves the value to be swapped and calls DepositOnly.
-// nolint:funlen
+//
+//nolint:funlen
 func (d *ERC20Depositor) Deposit(ctx context.Context, req DepositReq) (types.Transactions, error) {
 	lockKey := lockKey(req.Account.Address, req.Asset.EthAddress())
 	lock := handleLock(lockKey)

--- a/channel/erc20_depositor.go
+++ b/channel/erc20_depositor.go
@@ -63,7 +63,9 @@ func (d *ERC20Depositor) Deposit(ctx context.Context, req DepositReq) (types.Tra
 	if err != nil {
 		return nil, errors.WithMessagef(err, "creating transactor for asset: %x", req.Asset)
 	}
-	tx1, err := token.IncreaseAllowance(opts, req.Asset.EthAddress(), req.Balance)
+	// tx0, err := token.IncreaseAllowance(opts, req.Asset.EthAddress(), req.Balance)
+	tx1, err := token.Approve(opts, req.Asset.EthAddress(), req.Balance)
+
 	if err != nil {
 		err = cherrors.CheckIsChainNotReachableError(err)
 		return nil, errors.WithMessagef(err, "increasing allowance for asset: %x", req.Asset)

--- a/channel/funder.go
+++ b/channel/funder.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -151,6 +152,7 @@ func (f *Funder) Fund(ctx context.Context, request channel.FundingReq) error {
 	// Wait for the TXs to be mined.
 	for a, asset := range assets {
 		for i, tx := range txs[a] {
+			startFund := time.Now()
 			assetTyped, ok := asset.(*Asset)
 			if !ok {
 				return fmt.Errorf("wrong type: expected %T, got %T", &Asset{}, asset)
@@ -163,6 +165,8 @@ func (f *Funder) Fund(ctx context.Context, request channel.FundingReq) error {
 				return errors.WithMessagef(err, "sending %dth funding TX for asset %d", i, a)
 			}
 			f.log.Debugf("Mined TX: %v", tx.Hash().Hex())
+			elapsedFund := time.Since(startFund)
+			log.Printf("Waiting for asset %s to be funded tx %s in %s", asset, tx.Hash().Hex(), elapsedFund)
 		}
 	}
 

--- a/channel/funder.go
+++ b/channel/funder.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -152,7 +151,6 @@ func (f *Funder) Fund(ctx context.Context, request channel.FundingReq) error {
 	// Wait for the TXs to be mined.
 	for a, asset := range assets {
 		for i, tx := range txs[a] {
-			startFund := time.Now()
 			assetTyped, ok := asset.(*Asset)
 			if !ok {
 				return fmt.Errorf("wrong type: expected %T, got %T", &Asset{}, asset)
@@ -165,8 +163,6 @@ func (f *Funder) Fund(ctx context.Context, request channel.FundingReq) error {
 				return errors.WithMessagef(err, "sending %dth funding TX for asset %d", i, a)
 			}
 			f.log.Debugf("Mined TX: %v", tx.Hash().Hex())
-			elapsedFund := time.Since(startFund)
-			log.Printf("Waiting for asset %s to be funded tx %s in %s", asset, tx.Hash().Hex(), elapsedFund)
 		}
 	}
 

--- a/channel/funder.go
+++ b/channel/funder.go
@@ -175,11 +175,11 @@ func (f *Funder) Fund(ctx context.Context, request channel.FundingReq) error {
 	nonFundingErrg := perror.NewGatherer()
 	for _, err := range perror.Causes(errg.Wait()) {
 		if channel.IsAssetFundingError(err) && err != nil {
-			fudingErr, ok := err.(*channel.AssetFundingError)
+			fundingErr, ok := err.(*channel.AssetFundingError)
 			if !ok {
 				return fmt.Errorf("wrong type: expected %T, got %T", &channel.AssetFundingError{}, err)
 			}
-			fundingErrs = append(fundingErrs, fudingErr)
+			fundingErrs = append(fundingErrs, fundingErr)
 		} else if err != nil {
 			nonFundingErrg.Add(err)
 		}

--- a/channel/withdraw.go
+++ b/channel/withdraw.go
@@ -17,6 +17,7 @@ package channel
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -38,13 +39,19 @@ import (
 // Withdraw ensures that a channel has been concluded and the final outcome
 // withdrawn from the asset holders.
 func (a *Adjudicator) Withdraw(ctx context.Context, req channel.AdjudicatorReq, subStates channel.StateMap) error {
+	startEnsuredConcluded := time.Now()
 	if err := a.ensureConcluded(ctx, req, subStates); err != nil {
 		return errors.WithMessage(err, "ensure Concluded")
 	}
+	elapsedEnsuredConcluded := time.Since(startEnsuredConcluded)
+	log.Printf("EnsuredConcluded in %s", elapsedEnsuredConcluded)
 
+	startCheckConcluded := time.Now()
 	if err := a.checkConcludedState(ctx, req, subStates); err != nil {
 		return errors.WithMessage(err, "check concluded state")
 	}
+	elapsedCheckConcluded := time.Since(startCheckConcluded)
+	log.Printf("CheckConcluded in %s", elapsedCheckConcluded)
 
 	return errors.WithMessage(a.ensureWithdrawn(ctx, req), "ensure Withdrawn")
 }
@@ -64,6 +71,7 @@ func (a *Adjudicator) ensureWithdrawn(ctx context.Context, req channel.Adjudicat
 		}
 		asset := asset // Capture asset locally for usage in closure.
 		g.Go(func() error {
+			startWithdraw := time.Now()
 			// Create subscription
 			contract := bindAssetHolder(a.ContractBackend, asset, index)
 			fundingID := FundingIDs(req.Params.ID(), req.Params.Parts[req.Idx])[0]
@@ -97,16 +105,20 @@ func (a *Adjudicator) ensureWithdrawn(ctx context.Context, req channel.Adjudicat
 
 			select {
 			case <-events:
+				log.Printf("Withdraw asset %s in %s", asset, time.Since(startWithdraw))
 				return nil
 			case <-ctx.Done():
+				log.Printf("Withdraw asset %s in %s", asset, time.Since(startWithdraw))
 				return errors.Wrap(ctx.Err(), "context cancelled")
 			case err = <-subErr:
 				if err != nil {
 					return errors.WithMessage(err, "subscription error")
 				}
+				log.Printf("Withdraw asset %s in %s", asset, time.Since(startWithdraw))
 				return errors.New("subscription closed")
 			}
 		})
+
 	}
 	return g.Wait()
 }
@@ -146,22 +158,24 @@ func (a *Adjudicator) callAssetWithdraw(ctx context.Context, request channel.Adj
 		if err != nil {
 			return nil, errors.WithMessagef(err, "creating transactor for asset %d", asset.assetIndex)
 		}
-
 		tx, err := asset.Withdraw(trans, auth, sig)
 		if err != nil {
 			err = cherrors.CheckIsChainNotReachableError(err)
-			return nil, errors.WithMessagef(err, "withdrawing asset %d", asset.assetIndex)
+			return nil, errors.WithMessagef(err, "withdrawing asset %d with transaction nonce %d", asset.assetIndex, trans.Nonce)
 		}
-		log.Debugf("Sent transaction %v", tx.Hash().Hex())
+		log.Printf("Sent transaction %v at %s", tx.Hash().Hex(), time.Now())
 		return tx, nil
 	}()
 	if err != nil {
 		return err
 	}
+	startWithdraw := time.Now()
 	_, err = a.ConfirmTransaction(ctx, tx, a.txSender)
 	if err != nil && errors.Is(err, errTxTimedOut) {
 		err = client.NewTxTimedoutError(Withdraw.String(), tx.Hash().Hex(), err.Error())
 	}
+	elapsedWithdraw := time.Since(startWithdraw)
+	log.Printf("Wait for withdraw transaction of asset %s in %s", asset, elapsedWithdraw)
 	return errors.WithMessage(err, "mining transaction")
 }
 

--- a/channel/withdraw.go
+++ b/channel/withdraw.go
@@ -56,6 +56,7 @@ func (a *Adjudicator) Withdraw(ctx context.Context, req channel.AdjudicatorReq, 
 	return errors.WithMessage(a.ensureWithdrawn(ctx, req), "ensure Withdrawn")
 }
 
+//nolint:funlen
 func (a *Adjudicator) ensureWithdrawn(ctx context.Context, req channel.AdjudicatorReq) error {
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -118,7 +119,6 @@ func (a *Adjudicator) ensureWithdrawn(ctx context.Context, req channel.Adjudicat
 				return errors.New("subscription closed")
 			}
 		})
-
 	}
 	return g.Wait()
 }

--- a/channel/withdraw.go
+++ b/channel/withdraw.go
@@ -17,7 +17,6 @@ package channel
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -36,27 +35,19 @@ import (
 	"perun.network/go-perun/log"
 )
 
-// Withdraw ensures that a channel has been concluded and the final outcome
+// Withdraw ensures that a channel has been concluded and the final outcome.
 // withdrawn from the asset holders.
 func (a *Adjudicator) Withdraw(ctx context.Context, req channel.AdjudicatorReq, subStates channel.StateMap) error {
-	startEnsuredConcluded := time.Now()
 	if err := a.ensureConcluded(ctx, req, subStates); err != nil {
 		return errors.WithMessage(err, "ensure Concluded")
 	}
-	elapsedEnsuredConcluded := time.Since(startEnsuredConcluded)
-	log.Printf("EnsuredConcluded in %s", elapsedEnsuredConcluded)
-
-	startCheckConcluded := time.Now()
 	if err := a.checkConcludedState(ctx, req, subStates); err != nil {
 		return errors.WithMessage(err, "check concluded state")
 	}
-	elapsedCheckConcluded := time.Since(startCheckConcluded)
-	log.Printf("CheckConcluded in %s", elapsedCheckConcluded)
-
 	return errors.WithMessage(a.ensureWithdrawn(ctx, req), "ensure Withdrawn")
 }
 
-//nolint:funlen
+// ensureWithdrawn ensures that the channel has been withdrawn from the asset.
 func (a *Adjudicator) ensureWithdrawn(ctx context.Context, req channel.AdjudicatorReq) error {
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -72,7 +63,6 @@ func (a *Adjudicator) ensureWithdrawn(ctx context.Context, req channel.Adjudicat
 		}
 		asset := asset // Capture asset locally for usage in closure.
 		g.Go(func() error {
-			startWithdraw := time.Now()
 			// Create subscription
 			contract := bindAssetHolder(a.ContractBackend, asset, index)
 			fundingID := FundingIDs(req.Params.ID(), req.Params.Parts[req.Idx])[0]
@@ -84,7 +74,7 @@ func (a *Adjudicator) ensureWithdrawn(ctx context.Context, req channel.Adjudicat
 			}
 			defer sub.Close()
 
-			// Check for past event
+			// Check for past event.
 			if err := sub.ReadPast(ctx, events); err != nil {
 				return errors.WithMessage(err, "reading past events")
 			}
@@ -99,23 +89,20 @@ func (a *Adjudicator) ensureWithdrawn(ctx context.Context, req channel.Adjudicat
 				return errors.WithMessage(err, "withdrawing assets failed")
 			}
 
-			// Wait for event
+			// Wait for event.
 			go func() {
 				subErr <- sub.Read(ctx, events)
 			}()
 
 			select {
 			case <-events:
-				log.Printf("Withdraw asset %s in %s", asset, time.Since(startWithdraw))
 				return nil
 			case <-ctx.Done():
-				log.Printf("Withdraw asset %s in %s", asset, time.Since(startWithdraw))
 				return errors.Wrap(ctx.Err(), "context cancelled")
 			case err = <-subErr:
 				if err != nil {
 					return errors.WithMessage(err, "subscription error")
 				}
-				log.Printf("Withdraw asset %s in %s", asset, time.Since(startWithdraw))
 				return errors.New("subscription closed")
 			}
 		})
@@ -163,19 +150,15 @@ func (a *Adjudicator) callAssetWithdraw(ctx context.Context, request channel.Adj
 			err = cherrors.CheckIsChainNotReachableError(err)
 			return nil, errors.WithMessagef(err, "withdrawing asset %d with transaction nonce %d", asset.assetIndex, trans.Nonce)
 		}
-		log.Printf("Sent transaction %v at %s", tx.Hash().Hex(), time.Now())
 		return tx, nil
 	}()
 	if err != nil {
 		return err
 	}
-	startWithdraw := time.Now()
 	_, err = a.ConfirmTransaction(ctx, tx, a.txSender)
 	if err != nil && errors.Is(err, errTxTimedOut) {
 		err = client.NewTxTimedoutError(Withdraw.String(), tx.Hash().Hex(), err.Error())
 	}
-	elapsedWithdraw := time.Since(startWithdraw)
-	log.Printf("Wait for withdraw transaction of asset %s in %s", asset, elapsedWithdraw)
 	return errors.WithMessage(err, "mining transaction")
 }
 

--- a/client/fund_test.go
+++ b/client/fund_test.go
@@ -30,7 +30,7 @@ import (
 func TestFundRecovery(t *testing.T) {
 	rng := test.Prng(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	ctest.TestFundRecovery(

--- a/client/payment_test.go
+++ b/client/payment_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	twoPartyTestTimeout = 10 * time.Second
+	twoPartyTestTimeout = 60 * time.Second
 	TxFinalityDepth     = 3
 )
 

--- a/client/test/setup.go
+++ b/client/test/setup.go
@@ -29,11 +29,11 @@ import (
 
 const (
 	// DefaultTimeout is the default timeout for client tests.
-	DefaultTimeout = 5 * time.Second
+	DefaultTimeout = 20 * time.Second
 	// BlockInterval is the default block interval for the simulated chain.
-	BlockInterval = 100 * time.Millisecond
+	BlockInterval = 200 * time.Millisecond
 	// challenge duration in blocks that is used by MakeRoleSetups.
-	challengeDurationBlocks = 60
+	challengeDurationBlocks = 90
 )
 
 // MakeRoleSetups creates a two party client test setup with the provided names.


### PR DESCRIPTION
This pull request introduces several changes to the nonce handling and deposit process in order to address race conditions and improve overall reliability. The changes can be summarized as follows:

1. Mutex Lock for Deposit Process:

A mutex lock mechanism has been implemented to ensure that the deposit process is properly synchronized. This lock is activated when a deposit process is already running for the same address and asset. It prevents multiple concurrent deposit processes from interfering with each other, ensuring data consistency and integrity.

2. Event Listener for Approval:

An event listener for the "Approval" event has been added. Now, the deposit function will only be called if the "Allowance" has been increased. This enhancement prevents any discrepancies that might arise from the previous method of using increaseAllowance.

3. Improved Handling of Approval:

The pull request replaces the usage of increaseAllowance with Approve. This is necessary for Mainnet usability as some contracts do not include increaseAllowance.

4. Global Nonce:

The Nonce is handled globally for all clients to prevent race conditions for parallel swaps.
